### PR TITLE
help returns Yargs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare module yargs {
     exitProcess (enable: boolean): Yargs;
     fail (fn: (message: string) => any): Yargs;
     group (keys: string | string[], groupName: string): Yargs;
-    help (): string;
+    help (): Yargs;
     help (option?: string, description?: string): Yargs;
     implies (x: string, y: string): Yargs;
     locale (): string;


### PR DESCRIPTION
Fixes: Typings currently do not allow chaining of `help()` command.

Changes `help()` to return `Yargs` as per http://yargs.js.org/docs/#methods-helpoption-description